### PR TITLE
Support installation on Macs with M1 chips

### DIFF
--- a/ext/fasttext/extconf.rb
+++ b/ext/fasttext/extconf.rb
@@ -4,7 +4,7 @@ require "mkmf-rice"
 $CXXFLAGS << " -std=c++17 $(optflags) -funroll-loops "
 
 # Add -march=native if we're not on arm64
-if defined?(RUBY_PLATFORM) == 'constant' && RUBY_PLATFORM.split('-') != 'arm64'
+if defined?(RUBY_PLATFORM) == 'constant' && RUBY_PLATFORM.split('-')[0] != 'arm64'
   $CXXFLAGS << with_config("optflags", "-march=native")
 end
 

--- a/ext/fasttext/extconf.rb
+++ b/ext/fasttext/extconf.rb
@@ -1,12 +1,8 @@
 require "mkmf-rice"
 
 # -pthread and -O3 set by default
-$CXXFLAGS << " -std=c++17 $(optflags) -funroll-loops "
-
-# Add -march=native if we're not on arm64
-if defined?(RUBY_PLATFORM) == 'constant' && RUBY_PLATFORM.split('-')[0] != 'arm64'
-  $CXXFLAGS << with_config("optflags", "-march=native")
-end
+default_optflags = RbConfig::CONFIG["host_os"] =~ /darwin/i && RbConfig::CONFIG["host_cpu"] =~ /arm/i ? "" : "-march=native"
+$CXXFLAGS << " -std=c++17 $(optflags) -funroll-loops " << with_config("optflags", default_optflags)
 
 ext = File.expand_path(".", __dir__)
 fasttext = File.expand_path("../../vendor/fastText/src", __dir__)

--- a/ext/fasttext/extconf.rb
+++ b/ext/fasttext/extconf.rb
@@ -1,7 +1,12 @@
 require "mkmf-rice"
 
 # -pthread and -O3 set by default
-$CXXFLAGS << " -std=c++17 $(optflags) -funroll-loops " << with_config("optflags", "-march=native")
+$CXXFLAGS << " -std=c++17 $(optflags) -funroll-loops "
+
+# Add -march=native if we're not on arm64
+if defined?(RUBY_PLATFORM) == 'constant' && RUBY_PLATFORM.split('-') != 'arm64'
+  $CXXFLAGS << with_config("optflags", "-march=native")
+end
 
 ext = File.expand_path(".", __dir__)
 fasttext = File.expand_path("../../vendor/fastText/src", __dir__)


### PR DESCRIPTION
Fixes #3 

This builds on top of [@ukd1's great work here](https://github.com/ankane/fastText-ruby/pull/4) and applies the suggestion that @ankane made.

Results my my M1X Mac running Monterey

#### `bundle exec rake compile`
(Note: these are alllll warnings, and I am not 1337 enough to figure out if they are pertinent...)
```bash
mkdir -p tmp/arm64-darwin21/ext/2.7.4
cd tmp/arm64-darwin21/ext/2.7.4
/Users/zee/.asdf/installs/ruby/2.7.4/bin/ruby -I. ../../../../ext/fasttext/extconf.rb
checking for rice/rice.hpp in /Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include... yes
checking for -lc++... yes
creating Makefile
cd -
cd tmp/arm64-darwin21/ext/2.7.4
/usr/bin/make
compiling ../../../../ext/fasttext/ext.cpp
In file included from ../../../../ext/fasttext/ext.cpp:16:
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/rice.hpp:3073:56: warning: '(' and '{' tokens introducing statement expression appear in different macro expansion contexts [-Wcompound-token-split-by-macro]
      VALUE rubyMessage = rb_funcall(this->exception_, rb_intern("message"), 0);
                                                       ^~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:23: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                      ^
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:2689:27: note: expanded from macro 'rb_funcall'
        rb_funcallv(recv, mid, \
                          ^~~
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/rice.hpp:3073:56: note: '{' token is here
      VALUE rubyMessage = rb_funcall(this->exception_, rb_intern("message"), 0);
                                                       ^~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:24: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1832:5: note: expanded from macro 'RUBY_CONST_ID_CACHE'
    {                                                   \
    ^
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:2689:27: note: expanded from macro 'rb_funcall'
        rb_funcallv(recv, mid, \
                          ^~~
In file included from ../../../../ext/fasttext/ext.cpp:16:
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/rice.hpp:3073:56: warning: '}' and ')' tokens terminating statement expression appear in different macro expansion contexts [-Wcompound-token-split-by-macro]
      VALUE rubyMessage = rb_funcall(this->exception_, rb_intern("message"), 0);
                                                       ^~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:24: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1837:5: note: expanded from macro 'RUBY_CONST_ID_CACHE'
    }
    ^
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:2689:27: note: expanded from macro 'rb_funcall'
        rb_funcallv(recv, mid, \
                          ^~~
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/rice.hpp:3073:56: note: ')' token is here
      VALUE rubyMessage = rb_funcall(this->exception_, rb_intern("message"), 0);
                                                       ^~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:56: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                                                       ^
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:2689:27: note: expanded from macro 'rb_funcall'
        rb_funcallv(recv, mid, \
                          ^~~
In file included from ../../../../ext/fasttext/ext.cpp:16:
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/rice.hpp:3766:54: warning: '(' and '{' tokens introducing statement expression appear in different macro expansion contexts [-Wcompound-token-split-by-macro]
  inline Identifier::Identifier(char const* s) : id_(rb_intern(s))
                                                     ^~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:23: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                      ^
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/rice.hpp:3766:54: note: '{' token is here
  inline Identifier::Identifier(char const* s) : id_(rb_intern(s))
                                                     ^~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:24: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1832:5: note: expanded from macro 'RUBY_CONST_ID_CACHE'
    {                                                   \
    ^
In file included from ../../../../ext/fasttext/ext.cpp:16:
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/rice.hpp:3766:54: warning: '}' and ')' tokens terminating statement expression appear in different macro expansion contexts [-Wcompound-token-split-by-macro]
  inline Identifier::Identifier(char const* s) : id_(rb_intern(s))
                                                     ^~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:24: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1837:5: note: expanded from macro 'RUBY_CONST_ID_CACHE'
    }
    ^
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/rice.hpp:3766:54: note: ')' token is here
  inline Identifier::Identifier(char const* s) : id_(rb_intern(s))
                                                     ^~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:56: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                                                       ^
In file included from ../../../../ext/fasttext/ext.cpp:16:
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/rice.hpp:3770:60: warning: '(' and '{' tokens introducing statement expression appear in different macro expansion contexts [-Wcompound-token-split-by-macro]
  inline Identifier::Identifier(std::string const s) : id_(rb_intern(s.c_str()))
                                                           ^~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:23: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                      ^
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/rice.hpp:3770:60: note: '{' token is here
  inline Identifier::Identifier(std::string const s) : id_(rb_intern(s.c_str()))
                                                           ^~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:24: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1832:5: note: expanded from macro 'RUBY_CONST_ID_CACHE'
    {                                                   \
    ^
In file included from ../../../../ext/fasttext/ext.cpp:16:
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/rice.hpp:3770:60: warning: '}' and ')' tokens terminating statement expression appear in different macro expansion contexts [-Wcompound-token-split-by-macro]
  inline Identifier::Identifier(std::string const s) : id_(rb_intern(s.c_str()))
                                                           ^~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:24: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1837:5: note: expanded from macro 'RUBY_CONST_ID_CACHE'
    }
    ^
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/rice.hpp:3770:60: note: ')' token is here
  inline Identifier::Identifier(std::string const s) : id_(rb_intern(s.c_str()))
                                                           ^~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:56: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                                                       ^
In file included from ../../../../ext/fasttext/ext.cpp:16:
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/rice.hpp:4406:12: warning: '(' and '{' tokens introducing statement expression appear in different macro expansion contexts [-Wcompound-token-split-by-macro]
    return rb_intern(c_str());
           ^~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:23: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                      ^
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/rice.hpp:4406:12: note: '{' token is here
    return rb_intern(c_str());
           ^~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:24: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1832:5: note: expanded from macro 'RUBY_CONST_ID_CACHE'
    {                                                   \
    ^
In file included from ../../../../ext/fasttext/ext.cpp:16:
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/rice.hpp:4406:12: warning: '}' and ')' tokens terminating statement expression appear in different macro expansion contexts [-Wcompound-token-split-by-macro]
    return rb_intern(c_str());
           ^~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:24: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1837:5: note: expanded from macro 'RUBY_CONST_ID_CACHE'
    }
    ^
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/rice.hpp:4406:12: note: ')' token is here
    return rb_intern(c_str());
           ^~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:56: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                                                       ^
In file included from ../../../../ext/fasttext/ext.cpp:16:
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/rice.hpp:5250:42: warning: '(' and '{' tokens introducing statement expression appear in different macro expansion contexts [-Wcompound-token-split-by-macro]
      keys_ = rb_funcall(hash_->value(), rb_intern("keys"), 0, 0);
                                         ^~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:23: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                      ^
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:2689:27: note: expanded from macro 'rb_funcall'
        rb_funcallv(recv, mid, \
                          ^~~
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/rice.hpp:5250:42: note: '{' token is here
      keys_ = rb_funcall(hash_->value(), rb_intern("keys"), 0, 0);
                                         ^~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:24: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1832:5: note: expanded from macro 'RUBY_CONST_ID_CACHE'
    {                                                   \
    ^
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:2689:27: note: expanded from macro 'rb_funcall'
        rb_funcallv(recv, mid, \
                          ^~~
In file included from ../../../../ext/fasttext/ext.cpp:16:
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/rice.hpp:5250:42: warning: '}' and ')' tokens terminating statement expression appear in different macro expansion contexts [-Wcompound-token-split-by-macro]
      keys_ = rb_funcall(hash_->value(), rb_intern("keys"), 0, 0);
                                         ^~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:24: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1837:5: note: expanded from macro 'RUBY_CONST_ID_CACHE'
    }
    ^
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:2689:27: note: expanded from macro 'rb_funcall'
        rb_funcallv(recv, mid, \
                          ^~~
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/rice.hpp:5250:42: note: ')' token is here
      keys_ = rb_funcall(hash_->value(), rb_intern("keys"), 0, 0);
                                         ^~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:56: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                                                       ^
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:2689:27: note: expanded from macro 'rb_funcall'
        rb_funcallv(recv, mid, \
                          ^~~
In file included from ../../../../ext/fasttext/ext.cpp:16:
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/rice.hpp:5391:21: warning: '(' and '{' tokens introducing statement expression appear in different macro expansion contexts [-Wcompound-token-split-by-macro]
    : Object(ID2SYM(rb_intern(s)))
                    ^~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:23: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                      ^
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:414:29: note: expanded from macro 'ID2SYM'
#define ID2SYM(x) RB_ID2SYM(x)
                            ^
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:409:33: note: expanded from macro 'RB_ID2SYM'
#define RB_ID2SYM(x) (rb_id2sym(x))
                                ^
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/rice.hpp:5391:21: note: '{' token is here
    : Object(ID2SYM(rb_intern(s)))
                    ^~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:24: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1832:5: note: expanded from macro 'RUBY_CONST_ID_CACHE'
    {                                                   \
    ^
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:414:29: note: expanded from macro 'ID2SYM'
#define ID2SYM(x) RB_ID2SYM(x)
                            ^
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:409:33: note: expanded from macro 'RB_ID2SYM'
#define RB_ID2SYM(x) (rb_id2sym(x))
                                ^
In file included from ../../../../ext/fasttext/ext.cpp:16:
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/rice.hpp:5391:21: warning: '}' and ')' tokens terminating statement expression appear in different macro expansion contexts [-Wcompound-token-split-by-macro]
    : Object(ID2SYM(rb_intern(s)))
                    ^~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:24: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1837:5: note: expanded from macro 'RUBY_CONST_ID_CACHE'
    }
    ^
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:414:29: note: expanded from macro 'ID2SYM'
#define ID2SYM(x) RB_ID2SYM(x)
                            ^
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:409:33: note: expanded from macro 'RB_ID2SYM'
#define RB_ID2SYM(x) (rb_id2sym(x))
                                ^
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/rice.hpp:5391:21: note: ')' token is here
    : Object(ID2SYM(rb_intern(s)))
                    ^~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:56: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                                                       ^
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:414:29: note: expanded from macro 'ID2SYM'
#define ID2SYM(x) RB_ID2SYM(x)
                            ^
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:409:33: note: expanded from macro 'RB_ID2SYM'
#define RB_ID2SYM(x) (rb_id2sym(x))
                                ^
In file included from ../../../../ext/fasttext/ext.cpp:16:
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/rice.hpp:5396:21: warning: '(' and '{' tokens introducing statement expression appear in different macro expansion contexts [-Wcompound-token-split-by-macro]
    : Object(ID2SYM(rb_intern(s.c_str())))
                    ^~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:23: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                      ^
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:414:29: note: expanded from macro 'ID2SYM'
#define ID2SYM(x) RB_ID2SYM(x)
                            ^
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:409:33: note: expanded from macro 'RB_ID2SYM'
#define RB_ID2SYM(x) (rb_id2sym(x))
                                ^
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/rice.hpp:5396:21: note: '{' token is here
    : Object(ID2SYM(rb_intern(s.c_str())))
                    ^~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:24: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1832:5: note: expanded from macro 'RUBY_CONST_ID_CACHE'
    {                                                   \
    ^
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:414:29: note: expanded from macro 'ID2SYM'
#define ID2SYM(x) RB_ID2SYM(x)
                            ^
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:409:33: note: expanded from macro 'RB_ID2SYM'
#define RB_ID2SYM(x) (rb_id2sym(x))
                                ^
In file included from ../../../../ext/fasttext/ext.cpp:16:
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/rice.hpp:5396:21: warning: '}' and ')' tokens terminating statement expression appear in different macro expansion contexts [-Wcompound-token-split-by-macro]
    : Object(ID2SYM(rb_intern(s.c_str())))
                    ^~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:24: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1837:5: note: expanded from macro 'RUBY_CONST_ID_CACHE'
    }
    ^
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:414:29: note: expanded from macro 'ID2SYM'
#define ID2SYM(x) RB_ID2SYM(x)
                            ^
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:409:33: note: expanded from macro 'RB_ID2SYM'
#define RB_ID2SYM(x) (rb_id2sym(x))
                                ^
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/rice.hpp:5396:21: note: ')' token is here
    : Object(ID2SYM(rb_intern(s.c_str())))
                    ^~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:56: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                                                       ^
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:414:29: note: expanded from macro 'ID2SYM'
#define ID2SYM(x) RB_ID2SYM(x)
                            ^
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:409:33: note: expanded from macro 'RB_ID2SYM'
#define RB_ID2SYM(x) (rb_id2sym(x))
                                ^
In file included from ../../../../ext/fasttext/ext.cpp:17:
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/stl.hpp:141:47: warning: '(' and '{' tokens introducing statement expression appear in different macro expansion contexts [-Wcompound-token-split-by-macro]
      return protect(rb_funcall2, rb_mKernel, rb_intern("Complex"), (int)args.size(), (const VALUE*)args.data());
                                              ^~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:23: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                      ^
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/stl.hpp:141:47: note: '{' token is here
      return protect(rb_funcall2, rb_mKernel, rb_intern("Complex"), (int)args.size(), (const VALUE*)args.data());
                                              ^~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:24: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1832:5: note: expanded from macro 'RUBY_CONST_ID_CACHE'
    {                                                   \
    ^
In file included from ../../../../ext/fasttext/ext.cpp:17:
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/stl.hpp:141:47: warning: '}' and ')' tokens terminating statement expression appear in different macro expansion contexts [-Wcompound-token-split-by-macro]
      return protect(rb_funcall2, rb_mKernel, rb_intern("Complex"), (int)args.size(), (const VALUE*)args.data());
                                              ^~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:24: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1837:5: note: expanded from macro 'RUBY_CONST_ID_CACHE'
    }
    ^
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/stl.hpp:141:47: note: ')' token is here
      return protect(rb_funcall2, rb_mKernel, rb_intern("Complex"), (int)args.size(), (const VALUE*)args.data());
                                              ^~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:56: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                                                       ^
In file included from ../../../../ext/fasttext/ext.cpp:17:
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/stl.hpp:151:48: warning: '(' and '{' tokens introducing statement expression appear in different macro expansion contexts [-Wcompound-token-split-by-macro]
      VALUE real = protect(rb_funcall2, value, rb_intern("real"), 0, (const VALUE*)nullptr);
                                               ^~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:23: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                      ^
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/stl.hpp:151:48: note: '{' token is here
      VALUE real = protect(rb_funcall2, value, rb_intern("real"), 0, (const VALUE*)nullptr);
                                               ^~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:24: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1832:5: note: expanded from macro 'RUBY_CONST_ID_CACHE'
    {                                                   \
    ^
In file included from ../../../../ext/fasttext/ext.cpp:17:
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/stl.hpp:151:48: warning: '}' and ')' tokens terminating statement expression appear in different macro expansion contexts [-Wcompound-token-split-by-macro]
      VALUE real = protect(rb_funcall2, value, rb_intern("real"), 0, (const VALUE*)nullptr);
                                               ^~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:24: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1837:5: note: expanded from macro 'RUBY_CONST_ID_CACHE'
    }
    ^
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/stl.hpp:151:48: note: ')' token is here
      VALUE real = protect(rb_funcall2, value, rb_intern("real"), 0, (const VALUE*)nullptr);
                                               ^~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:56: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                                                       ^
In file included from ../../../../ext/fasttext/ext.cpp:17:
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/stl.hpp:152:53: warning: '(' and '{' tokens introducing statement expression appear in different macro expansion contexts [-Wcompound-token-split-by-macro]
      VALUE imaginary = protect(rb_funcall2, value, rb_intern("imaginary"), 0, (const VALUE*)nullptr);
                                                    ^~~~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:23: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                      ^
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/stl.hpp:152:53: note: '{' token is here
      VALUE imaginary = protect(rb_funcall2, value, rb_intern("imaginary"), 0, (const VALUE*)nullptr);
                                                    ^~~~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:24: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1832:5: note: expanded from macro 'RUBY_CONST_ID_CACHE'
    {                                                   \
    ^
In file included from ../../../../ext/fasttext/ext.cpp:17:
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/stl.hpp:152:53: warning: '}' and ')' tokens terminating statement expression appear in different macro expansion contexts [-Wcompound-token-split-by-macro]
      VALUE imaginary = protect(rb_funcall2, value, rb_intern("imaginary"), 0, (const VALUE*)nullptr);
                                                    ^~~~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:24: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1837:5: note: expanded from macro 'RUBY_CONST_ID_CACHE'
    }
    ^
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/stl.hpp:152:53: note: ')' token is here
      VALUE imaginary = protect(rb_funcall2, value, rb_intern("imaginary"), 0, (const VALUE*)nullptr);
                                                    ^~~~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:56: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                                                       ^
In file included from ../../../../ext/fasttext/ext.cpp:17:
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/stl.hpp:164:48: warning: '(' and '{' tokens introducing statement expression appear in different macro expansion contexts [-Wcompound-token-split-by-macro]
      VALUE real = protect(rb_funcall2, value, rb_intern("real"), 0, (const VALUE*)nullptr);
                                               ^~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:23: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                      ^
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/stl.hpp:164:48: note: '{' token is here
      VALUE real = protect(rb_funcall2, value, rb_intern("real"), 0, (const VALUE*)nullptr);
                                               ^~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:24: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1832:5: note: expanded from macro 'RUBY_CONST_ID_CACHE'
    {                                                   \
    ^
In file included from ../../../../ext/fasttext/ext.cpp:17:
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/stl.hpp:164:48: warning: '}' and ')' tokens terminating statement expression appear in different macro expansion contexts [-Wcompound-token-split-by-macro]
      VALUE real = protect(rb_funcall2, value, rb_intern("real"), 0, (const VALUE*)nullptr);
                                               ^~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:24: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1837:5: note: expanded from macro 'RUBY_CONST_ID_CACHE'
    }
    ^
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/stl.hpp:164:48: note: ')' token is here
      VALUE real = protect(rb_funcall2, value, rb_intern("real"), 0, (const VALUE*)nullptr);
                                               ^~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:56: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                                                       ^
In file included from ../../../../ext/fasttext/ext.cpp:17:
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/stl.hpp:165:53: warning: '(' and '{' tokens introducing statement expression appear in different macro expansion contexts [-Wcompound-token-split-by-macro]
      VALUE imaginary = protect(rb_funcall2, value, rb_intern("imaginary"), 0, (const VALUE*)nullptr);
                                                    ^~~~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:23: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                      ^
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/stl.hpp:165:53: note: '{' token is here
      VALUE imaginary = protect(rb_funcall2, value, rb_intern("imaginary"), 0, (const VALUE*)nullptr);
                                                    ^~~~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:24: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1832:5: note: expanded from macro 'RUBY_CONST_ID_CACHE'
    {                                                   \
    ^
In file included from ../../../../ext/fasttext/ext.cpp:17:
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/stl.hpp:165:53: warning: '}' and ')' tokens terminating statement expression appear in different macro expansion contexts [-Wcompound-token-split-by-macro]
      VALUE imaginary = protect(rb_funcall2, value, rb_intern("imaginary"), 0, (const VALUE*)nullptr);
                                                    ^~~~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:24: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1837:5: note: expanded from macro 'RUBY_CONST_ID_CACHE'
    }
    ^
/Users/zee/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/rice-4.0.2/include/rice/stl.hpp:165:53: note: ')' token is here
      VALUE imaginary = protect(rb_funcall2, value, rb_intern("imaginary"), 0, (const VALUE*)nullptr);
                                                    ^~~~~~~~~~~~~~~~~~~~~~
/Users/zee/.asdf/installs/ruby/2.7.4/include/ruby-2.7.0/ruby/ruby.h:1847:56: note: expanded from macro 'rb_intern'
        __extension__ (RUBY_CONST_ID_CACHE((ID), (str))) : \
                                                       ^
24 warnings generated.
compiling /Users/zee/Projects/oss/fastText-ruby/vendor/fastText/src/dictionary.cc
compiling /Users/zee/Projects/oss/fastText-ruby/vendor/fastText/src/main.cc
compiling /Users/zee/Projects/oss/fastText-ruby/vendor/fastText/src/autotune.cc
compiling /Users/zee/Projects/oss/fastText-ruby/vendor/fastText/src/fasttext.cc
compiling /Users/zee/Projects/oss/fastText-ruby/vendor/fastText/src/utils.cc
compiling /Users/zee/Projects/oss/fastText-ruby/vendor/fastText/src/model.cc
compiling /Users/zee/Projects/oss/fastText-ruby/vendor/fastText/src/loss.cc
compiling /Users/zee/Projects/oss/fastText-ruby/vendor/fastText/src/productquantizer.cc
compiling /Users/zee/Projects/oss/fastText-ruby/vendor/fastText/src/args.cc
compiling /Users/zee/Projects/oss/fastText-ruby/vendor/fastText/src/quantmatrix.cc
compiling /Users/zee/Projects/oss/fastText-ruby/vendor/fastText/src/matrix.cc
compiling /Users/zee/Projects/oss/fastText-ruby/vendor/fastText/src/meter.cc
compiling /Users/zee/Projects/oss/fastText-ruby/vendor/fastText/src/vector.cc
compiling /Users/zee/Projects/oss/fastText-ruby/vendor/fastText/src/densematrix.cc
linking shared-object fasttext/ext.bundle
cd -
mkdir -p tmp/arm64-darwin21/stage/lib/fasttext
install -c tmp/arm64-darwin21/ext/2.7.4/ext.bundle lib/fasttext/ext.bundle
cp tmp/arm64-darwin21/ext/2.7.4/ext.bundle tmp/arm64-darwin21/stage/lib/fasttext/ext.bundle
```
#### `bundle exec rake test`

```
Run options: --seed 10698

# Running:

Progress: 100.0% Trials:   10 Best score:  1.000000 ETA:   0h 0m 0s
Training again with best arguments
Read 0M words
Number of words:  14
Number of labels: 2
Progress: 100.0% words/sec/thread:    1046 lr:  0.000000 avg.loss:  0.693706 ETA:   0h 0m 0s
Read 0M words
Number of words:  14
Number of labels: 2
Progress: 100.0% words/sec/thread:     707 lr:  0.000000 avg.loss:  0.694351 ETA:   0h 0m 0s
Read 0M words
Number of words:  14
Number of labels: 2
Progress: 100.0% words/sec/thread:     688 lr:  0.000000 avg.loss:  0.693378 ETA:   0h 0m 0s
Read 0M words
Number of words:  14
Number of labels: 2
Progress: 100.0% words/sec/thread: 1615384 lr:  0.000000 avg.loss:  0.693582 ETA:   0h 0m 0s
Progress: 100.0% Trials:   10 Best score:  1.000000 ETA:   0h 0m 0s
Training again with best arguments
Read 0M words
Number of words:  14
Number of labels: 2
Progress: 100.0% words/sec/thread:    1071 lr:  0.000000 avg.loss:  0.693706 ETA:   0h 0m 0s
Progress: 100.0% Trials:   10 Best score:  1.000000 ETA:   0h 0m 0s
Training again with best arguments
Read 0M words
Number of words:  14
Number of labels: 2
Progress: 100.0% words/sec/thread:    1041 lr:  0.000000 avg.loss:  0.693706 ETA:   0h 0m 0s
Read 0M words
Number of words:  5
Number of labels: 0
Progress: 100.0% words/sec/thread:     329 lr:  0.000000 avg.loss:       nan ETA:   0h 0m 0s
Read 0M words
Number of words:  5
Number of labels: 0
Progress: 100.0% words/sec/thread:     333 lr:  0.000000 avg.loss:       nan ETA:   0h 0m 0s
Read 0M words
Number of words:  5
Number of labels: 0
Progress: 100.0% words/sec/thread:     329 lr:  0.000000 avg.loss:       nan ETA:   0h 0m 0s
.

Fabulous run in 12.941991s, 0.8499 runs/s, 3.0907 assertions/s.

11 runs, 40 assertions, 0 failures, 0 errors, 1 skips

You have skipped tests. Run with --verbose for details.
```